### PR TITLE
Add borderless fullscreen mode

### DIFF
--- a/CUIElement.cpp
+++ b/CUIElement.cpp
@@ -82,6 +82,55 @@ void CUIElement::GetColors() noexcept
     _BackgroundColor = Helper.get_colour(cui::colours::colour_background);
 }
 
+/// <summary>
+/// Toggles borderless fullscreen mode.
+/// </summary>
+void CUIElement::ToggleFullScreen() noexcept
+{
+    if (!_IsFullscreen)
+    {
+        RECT r{};
+        const HMONITOR hMonitor = ::MonitorFromWindow(m_hWnd, MONITOR_DEFAULTTONEAREST);
+        if (hMonitor)
+        {
+            MONITORINFOEX mix = {{sizeof(mix)}};
+            if (::GetMonitorInfo(hMonitor, &mix))
+            {
+                r = mix.rcMonitor;
+            }
+        }
+        const int w = max(0, r.right - r.left);
+        const int h = max(0, r.bottom - r.top);
+        const HWND z = HWND_TOP;
+
+        const HWND window = m_hWnd;
+        _PreviousWP = {sizeof(_PreviousWP)};
+        ::GetWindowPlacement(window, &_PreviousWP);
+        _PreviousStyle = ::GetWindowLongPtr(window, GWL_STYLE);
+        _PreviousExStyle = ::GetWindowLongPtr(window, GWL_EXSTYLE);
+        UINT flags = SWP_NOZORDER | SWP_FRAMECHANGED;
+
+        ::SetWindowLongPtr(window, GWL_STYLE, (_PreviousStyle & ~(WS_CHILD | WS_OVERLAPPEDWINDOW)) | WS_POPUP);
+        ::SetWindowLongPtr(window, GWL_EXSTYLE, _PreviousExStyle & ~WS_EX_TOPMOST);
+        ::SetParent(window, NULL);
+        ::SetWindowPos(window, z, r.left, r.top, w, h, flags);
+
+        _IsFullscreen = true;
+    }
+    else
+    {
+        const HWND window = m_hWnd;
+        ::SetWindowLongPtr(window, GWL_STYLE, _PreviousStyle);
+        ::SetWindowLongPtr(window, GWL_EXSTYLE, _PreviousExStyle);
+        ::SetParent(window, _hParent);
+        ::SetWindowPlacement(window, &_PreviousWP);
+        ::SetWindowPos(window, HWND_TOP, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_FRAMECHANGED);
+        ::SetFocus(core_api::get_main_window());
+
+        _IsFullscreen = false;
+    }
+}
+
 static uie::window_factory<CUIElement> _WindowFactory;
 
 #pragma endregion

--- a/CUIElement.h
+++ b/CUIElement.h
@@ -113,7 +113,8 @@ public:
 
 private:
     window_host_ptr _Host;
-    HWND _hParent;
+
+    void ToggleFullScreen() noexcept override;
 };
 
 static std::vector<CUIElement *> _Elements; // Very ugly but necessary because of the weird CUI notification mechanism.

--- a/DUIElement.cpp
+++ b/DUIElement.cpp
@@ -135,6 +135,73 @@ void DUIElement::GetColors() noexcept
     _BackgroundColor = (COLORREF) m_callback->query_std_color(ui_color_background);
 }
 
+/// <summary>
+/// Retrieves a window's parent or owner.
+/// </summary>
+static HWND GetRealParent(HWND hWnd) noexcept
+{
+    HWND hWndOwner;
+
+    // To obtain a window's owner window, instead of using `GetParent()`,
+    // use `GetWindow()` with the `GW_OWNER` flag.
+    if ((hWndOwner = ::GetWindow(hWnd, GW_OWNER)) != NULL)
+        return hWndOwner;
+
+    // Obtain the parent window and not the owner.
+    return ::GetAncestor(hWnd, GA_PARENT);
+}
+
+/// <summary>
+/// Toggles borderless fullscreen mode.
+/// </summary>
+void DUIElement::ToggleFullScreen() noexcept
+{
+    if (!_IsFullscreen)
+    {
+        RECT r{};
+        _hParent = GetRealParent(m_hWnd);
+        const HMONITOR hMonitor = ::MonitorFromWindow(m_hWnd, MONITOR_DEFAULTTONEAREST);
+        if (hMonitor)
+        {
+            MONITORINFOEX mix = {{sizeof(mix)}};
+            if (::GetMonitorInfo(hMonitor, &mix))
+            {
+                r = mix.rcMonitor;
+            }
+        }
+        const int w = max(0, r.right - r.left);
+        const int h = max(0, r.bottom - r.top);
+        const HWND z = HWND_TOP;
+
+        const HWND window = m_hWnd;
+        _PreviousWP = {sizeof(_PreviousWP)};
+        ::GetWindowPlacement(window, &_PreviousWP);
+        _hOwner = ::GetWindow(window, GW_OWNER);
+        _PreviousStyle = ::GetWindowLongPtr(window, GWL_STYLE);
+        _PreviousExStyle = ::GetWindowLongPtr(window, GWL_EXSTYLE);
+        UINT flags = SWP_NOZORDER | (_hOwner ? SWP_NOOWNERZORDER : 0u) | SWP_FRAMECHANGED;
+
+        ::SetWindowLongPtr(window, GWL_STYLE, (_PreviousStyle & ~(WS_CHILD | WS_OVERLAPPEDWINDOW)) | WS_POPUP);
+        ::SetWindowLongPtr(window, GWL_EXSTYLE, _PreviousExStyle & ~WS_EX_TOPMOST);
+        ::SetParent(window, NULL);
+        ::SetWindowPos(window, z, r.left, r.top, w, h, flags);
+
+        _IsFullscreen = true;
+    }
+    else
+    {
+        const HWND window = m_hWnd;
+        ::SetWindowLongPtr(window, GWL_STYLE, _PreviousStyle);
+        ::SetWindowLongPtr(window, GWL_EXSTYLE, _PreviousExStyle);
+        ::SetParent(window, _hParent);
+        ::SetWindowPlacement(window, &_PreviousWP);
+        ::SetWindowPos(window, HWND_TOP, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | (_hOwner ? SWP_NOOWNERZORDER : 0u) | SWP_FRAMECHANGED);
+        ::SetFocus(core_api::get_main_window());
+
+        _IsFullscreen = false;
+    }
+}
+
 static service_factory_single_t<ui_element_impl_withpopup<DUIElement>> _Factory;
 
 #pragma endregion

--- a/DUIElement.h
+++ b/DUIElement.h
@@ -48,4 +48,7 @@ public:
 
 protected:
     ui_element_instance_callback::ptr m_callback; // Don't rename this. BumpableElement uses it.
+
+private:
+    void ToggleFullScreen() noexcept override;
 };

--- a/UIElement.cpp
+++ b/UIElement.cpp
@@ -180,6 +180,25 @@ void UIElement::OnPaint(CDCHandle dc) noexcept
 }
 
 /// <summary>
+/// Implements "Alt + Enter" key combination to toggle fullscreen mode.
+/// </summary>
+void UIElement::OnSysKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags) noexcept
+{
+    UNREFERENCED_PARAMETER(nRepCnt);
+
+    // Bit 29: The context code. The value is 1 if the Alt key is down while the
+    //         key is pressed; it is 0 if the `WM_SYSKEYDOWN` message is posted to
+    //         the active window because no window has the keyboard focus.
+    // Bit 30: The previous key state. The value is 1 if the key is down before
+    //         the message is sent, or it is 0 if the key is up.
+    if (nChar == VK_RETURN && (nFlags & 0x6000) == 0x2000)
+    {
+        ToggleFullScreen();
+        return;
+    }
+}
+
+/// <summary>
 /// Handles a change to the template. Either the path name or the content changed.
 /// </summary>
 LRESULT UIElement::OnTemplateChanged(UINT msg, WPARAM wParam, LPARAM lParam) noexcept

--- a/UIElement.h
+++ b/UIElement.h
@@ -182,6 +182,7 @@ private:
     void OnSize(UINT nType, CSize size) noexcept;
     BOOL OnEraseBackground(CDCHandle dc) noexcept;
     void OnPaint(CDCHandle dc) noexcept;
+    void OnSysKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags) noexcept;
     LRESULT OnTemplateChanged(UINT msg, WPARAM wParam, LPARAM lParam) noexcept;
     LRESULT OnWebViewReady(UINT msg, WPARAM wParam, LPARAM lParam) noexcept;
     LRESULT OnAsync(UINT msg, WPARAM wParam, LPARAM lParam) noexcept;
@@ -192,6 +193,7 @@ private:
         MSG_WM_SIZE(OnSize)
         MSG_WM_ERASEBKGND(OnEraseBackground)
         MSG_WM_PAINT(OnPaint)
+        MSG_WM_SYSKEYDOWN(OnSysKeyDown)
 
         MESSAGE_HANDLER_EX(UM_TEMPLATE_CHANGED, OnTemplateChanged)
         MESSAGE_HANDLER_EX(UM_WEB_VIEW_READY, OnWebViewReady)
@@ -240,6 +242,13 @@ protected:
     COLORREF _ForegroundColor;
     COLORREF _BackgroundColor;
 
+    bool _IsFullscreen = false;
+    WINDOWPLACEMENT _PreviousWP;
+    LONG_PTR _PreviousStyle;
+    LONG_PTR _PreviousExStyle;
+    HWND _hParent;
+    HWND _hOwner;
+
 private:
     fb2k::CCoreDarkModeHooks _DarkMode;
     playback_control::ptr _PlaybackControl;
@@ -272,4 +281,6 @@ private:
     uint32_t _SampleRate;
 
     SharedBuffer _SharedBuffer;
+
+    virtual void ToggleFullScreen() noexcept = 0;
 };

--- a/WebView.cpp
+++ b/WebView.cpp
@@ -658,16 +658,16 @@ HRESULT UIElement::CreateContextMenu(const wchar_t * itemLabel, const wchar_t * 
         if (!SUCCEEDED(hr))
             return hr;
 
-        wil::com_ptr<ICoreWebView2ContextMenuItem> ContextMenuItem;
+        wil::com_ptr<ICoreWebView2ContextMenuItem> PreferencesMenuItem;
 
         // Creates a menu item.
         {
-            hr = Environment9->CreateContextMenuItem(L"Preferences", nullptr, COREWEBVIEW2_CONTEXT_MENU_ITEM_KIND_COMMAND, &ContextMenuItem);
+            hr = Environment9->CreateContextMenuItem(L"Preferences", nullptr, COREWEBVIEW2_CONTEXT_MENU_ITEM_KIND_COMMAND, &PreferencesMenuItem);
 
             if (!SUCCEEDED(hr))
                 return hr;
 
-            hr = ContextMenuItem->add_CustomItemSelected(Callback<ICoreWebView2CustomItemSelectedEventHandler>
+            hr = PreferencesMenuItem->add_CustomItemSelected(Callback<ICoreWebView2CustomItemSelectedEventHandler>
             (
                 [this](ICoreWebView2ContextMenuItem * sender, IUnknown * args)
                 {
@@ -681,7 +681,33 @@ HRESULT UIElement::CreateContextMenu(const wchar_t * itemLabel, const wchar_t * 
                 return hr;
         }
 
-        hr = Children->InsertValueAtIndex(0, ContextMenuItem.get());
+        wil::com_ptr<ICoreWebView2ContextMenuItem> FullscreenMenuItem;
+        {
+            hr = Environment9->CreateContextMenuItem(L"Fullscreen", nullptr, COREWEBVIEW2_CONTEXT_MENU_ITEM_KIND_COMMAND, &FullscreenMenuItem);
+
+            if (!SUCCEEDED(hr))
+                return hr;
+
+            hr = FullscreenMenuItem->add_CustomItemSelected(Callback<ICoreWebView2CustomItemSelectedEventHandler>
+                (
+                    [this](ICoreWebView2ContextMenuItem* sender, IUnknown* args)
+                    {
+                        RunAsync([this] { ToggleFullScreen(); });
+
+                        return S_OK;
+                    }
+                ).Get(), nullptr);
+
+            if (!SUCCEEDED(hr))
+                return hr;
+        }
+
+        hr = Children->InsertValueAtIndex(0, PreferencesMenuItem.get());
+
+        if (!SUCCEEDED(hr))
+            return hr;
+
+        hr = Children->InsertValueAtIndex(1, FullscreenMenuItem.get());
     }
 
     return hr;


### PR DESCRIPTION
Adds the capability to the component running as both a Default UI element and a Columns UI panel to expand its window to occupy the entire screen.

In addition, adds a context menu item to toggle the fullscreen state as well as the traditional game **Alt**+**Enter** keyboard shortcut.